### PR TITLE
fix(brew-formula): update the sha256 of the package

### DIFF
--- a/Formula/gefyra.rb
+++ b/Formula/gefyra.rb
@@ -2,7 +2,7 @@ class Gefyra < Formula
   desc "Blazingly-fast, rock-solid, local application development with Kubernetes"
   homepage "https://gefyra.dev"
   url "https://github.com/gefyrahq/gefyra/releases/download/2.2.3/gefyra-2.2.3-darwin-universal.zip"
-  sha256 "2c98df9c9f0375aceb698814bda6ff20ea5c75fd4158a3f82f19e3b400900f5b"
+  sha256 "e7a44280842b2a55069875c873ef1fd4077f086cce934a2d57517ae8690e702e"
   license "Apache-2.0"
 
   def install


### PR DESCRIPTION
Issue: https://github.com/gefyrahq/gefyra/issues/756

Brew fails sha256 checksum when installing the package.

After checking it

```shell
wget https://github.com/gefyrahq/gefyra/releases/download/2.2.3/gefyra-2.2.3-darwin-universal.zip 
shasum -a 256 gefyra-2.2.3-darwin-universal.zip
```

Returns `e7a44280842b2a55069875c873ef1fd4077f086cce934a2d57517ae8690e702e`
